### PR TITLE
Fix colorspace dependency to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "jupyterhub-quickstart",
   "version": "1.0.0",
   "main": "index.js",
+  "comments": {
+    "colorspace": "fixed to 1.1.2 because it is an indirect dependency of @dabh/diagnostics which is specifying 1.1.x"
+  },
   "dependencies": {
     "async": "3.2.1",
     "color-name": "1.1.4",
     "color-string": "1.5.5",
+    "colorspace": "1.1.2",
     "configurable-http-proxy": "4.2.3",
     "core-util-is": "1.0.3",
     "fecha": "4.2.1",


### PR DESCRIPTION
Also added a comment field to package.json for tracking these
kinds of changes.

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
