### PR TITLE
Fix winston-transport dependency to 4.4.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "comments": {
     "colorspace": "fixed to 1.1.2 because it is an indirect dependency of @dabh/diagnostics which is specifying 1.1.x",
-    "strftime": "fixed to 0.10.0 because it is an indirect dependency of @configurable-http-proxy"
+    "strftime": "fixed to 0.10.0 because it is an indirect dependency of @configurable-http-proxy",
+    "winston-transport": "fixed to 4.4.0 because it is an indirect dependency of @configurable-http-proxy"
   },
   "dependencies": {
     "async": "3.2.1",
@@ -16,6 +17,7 @@
     "fecha": "4.2.1",
     "follow-redirects": "1.13.3",
     "is-stream": "2.0.1",
-    "strftime": "0.10.0"
+    "strftime": "0.10.0",
+    "winston-transport": "4.4.0"
   }
 }


### PR DESCRIPTION
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
